### PR TITLE
fix: github link, feat: markdown descriptions, filter/mobile improvem…

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,3 @@ See the [Prisma Documentation](https://www.prisma.io/docs/orm/tools/prisma-cli) 
 1. Set the environment variables in `.env` or in you hosting provider's environment variable settings.
 2. Run `bun run build` to create a production build
 3. Run `bun run start` to start the production server
-
-## Unimplemented Features (considering)
-
-- Exporting as images
-  - Customizing color theme?
-- Better email templates
-- Notify contributors of suspensions/model removals
-- Change requests (adding/editing/removing an LLM's metadata field)

--- a/app/about/about.tsx
+++ b/app/about/about.tsx
@@ -87,6 +87,7 @@ export default function About({
                 field={{
                   type: MetaPropertyType.Number,
                   name: "Humaneval Performance",
+                  nonNullCount: 5,
                   values: [
                     ["code-llama", 28.8],
                     ["mistral-7b", 30.5],
@@ -100,6 +101,7 @@ export default function About({
                 field={{
                   type: MetaPropertyType.Number,
                   name: "Context Tokens",
+                  nonNullCount: 5,
                   values: [
                     ["gpt-4", 8192],
                     ["gpt-3.5-turbo", 4096],
@@ -113,6 +115,7 @@ export default function About({
                 field={{
                   type: MetaPropertyType.String,
                   name: "Use Case",
+                  nonNullCount: 5,
                   values: [
                     ["gpt-4", "text generation"],
                     ["dalle-2", "text-to-image"],

--- a/app/compare/comparison.tsx
+++ b/app/compare/comparison.tsx
@@ -6,11 +6,31 @@ import { styled } from "react-tailwind-variants"
 import Controls from "./controls"
 import CompareItem from "./item"
 import { llmsAtom, optionsAtom, sidebarAtom } from "./state"
+import { MetaPropertyType } from "@prisma/client"
 
 export default function Comparison() {
   const [llms] = useAtom(llmsAtom)
   const [, setOpen] = useAtom(sidebarAtom)
-  const [{ view }] = useAtom(optionsAtom)
+  const [{ view, filter }] = useAtom(optionsAtom)
+
+  const items = toMutualMetadata(llms)
+    .filter(l => (filter.includes("standalone") ? true : l.nonNullCount > 1))
+    .filter(l =>
+      filter.includes(MetaPropertyType.Number)
+        ? true
+        : l.type !== MetaPropertyType.Number
+    )
+    .filter(l =>
+      filter.includes(MetaPropertyType.String)
+        ? true
+        : l.type !== MetaPropertyType.String
+    )
+    .filter(l =>
+      filter.includes(MetaPropertyType.Boolean)
+        ? true
+        : l.type !== MetaPropertyType.Boolean
+    )
+    .filter(l => (filter.includes("nullFields") ? true : l.nonNullCount > 0))
 
   return (
     <Container>
@@ -18,7 +38,7 @@ export default function Comparison() {
       <ContainerOverflow>
         {llms.length > 1 ? (
           <ItemsContainer view={view}>
-            {toMutualMetadata(llms).map((x, i) => (
+            {items.map((x, i) => (
               <CompareItem key={i} field={x} />
             ))}
           </ItemsContainer>

--- a/app/compare/item/boolean-table.tsx
+++ b/app/compare/item/boolean-table.tsx
@@ -6,10 +6,12 @@ import { styled } from "react-tailwind-variants"
 import { optionsAtom } from "../state"
 
 export default function BooleanTable({ field }: { field: ComparableField }) {
-  const [{ showNullFields, sort }] = useAtom(optionsAtom)
+  const [{ filter, sort }] = useAtom(optionsAtom)
 
   const fields = (
-    showNullFields ? field.values : field.values.filter(([, v]) => v !== null)
+    filter.includes("nullFields")
+      ? field.values
+      : field.values.filter(([, v]) => v !== null)
   ).toSorted((a, b) => {
     switch (sort) {
       case "value-asc":

--- a/app/compare/item/numeric-chart.tsx
+++ b/app/compare/item/numeric-chart.tsx
@@ -6,10 +6,12 @@ import { styled } from "react-tailwind-variants"
 import { optionsAtom } from "../state"
 
 export default function NumericChart({ field }: { field: ComparableField }) {
-  const [{ showNullFields, sort }] = useAtom(optionsAtom)
+  const [{ filter, sort }] = useAtom(optionsAtom)
 
   const rows = (
-    showNullFields ? field.values : field.values.filter(([, v]) => v !== null)
+    filter.includes("nullFields")
+      ? field.values
+      : field.values.filter(([, v]) => v !== null)
   ).toSorted((a, b) => {
     switch (sort) {
       case "value-asc":

--- a/app/compare/item/string-table.tsx
+++ b/app/compare/item/string-table.tsx
@@ -5,10 +5,12 @@ import { styled } from "react-tailwind-variants"
 import { optionsAtom } from "../state"
 
 export default function StringTable({ field }: { field: ComparableField }) {
-  const [{ showNullFields, sort }] = useAtom(optionsAtom)
+  const [{ filter, sort }] = useAtom(optionsAtom)
 
   const fields = (
-    showNullFields ? field.values : field.values.filter(([, v]) => v !== null)
+    filter.includes("nullFields")
+      ? field.values
+      : field.values.filter(([, v]) => v !== null)
   ).toSorted((a, b) => {
     switch (sort) {
       case "value-asc":

--- a/app/compare/state.ts
+++ b/app/compare/state.ts
@@ -1,4 +1,4 @@
-import { Field, LLM, MetaProperty } from "@prisma/client"
+import { Field, LLM, MetaProperty, MetaPropertyType } from "@prisma/client"
 import { atom } from "jotai"
 
 export type LLMWithMetadata = LLM & {
@@ -17,12 +17,27 @@ export type FieldSort =
 
 export interface ControlOptions {
   view: "grid" | "list"
-  showNullFields: boolean
   sort: FieldSort
+  filter: Array<FilterType>
 }
+
+export const filterOptions = {
+  [MetaPropertyType.Number]: "Numeric fields",
+  [MetaPropertyType.String]: "String fields",
+  [MetaPropertyType.Boolean]: "Boolean fields",
+  nullFields: "Null fields",
+  standalone: "Standalone fields"
+}
+
+export type FilterType = keyof typeof filterOptions
 
 export const optionsAtom = atom<ControlOptions>({
   view: "grid",
-  showNullFields: true,
-  sort: "default"
+  sort: "default",
+  filter: [
+    MetaPropertyType.String,
+    MetaPropertyType.Number,
+    MetaPropertyType.Boolean,
+    "nullFields"
+  ]
 })

--- a/app/llms/components/LLMOverlay/index.tsx
+++ b/app/llms/components/LLMOverlay/index.tsx
@@ -165,7 +165,7 @@ export default function LLMOverlay() {
 
             <ContentSection>
               <Text weight="medium">Source Description</Text>
-              <Text multiline color="dimmer">
+              <Text multiline markdown color="dimmer">
                 {llm.sourceDescription}
               </Text>
             </ContentSection>
@@ -175,6 +175,7 @@ export default function LLMOverlay() {
                 Uploaded by{" "}
                 <a
                   href={`https://github.com/${llm.user.handle}`}
+                  target="_blank"
                   className="text-accent-dimmer border-b border-accent-dimmer"
                 >
                   {llm.user.handle}

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -22,11 +22,11 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-10 min-w-36 items-center justify-between rounded-lg border-2 px-4 py-2 text-sm placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 outline-none",
+      "flex min-w-36 items-center justify-between border-2 px-4 text-sm placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 outline-none",
       elevated
         ? "bg-higher border-outline-dimmer focus:border-accent-dimmer data-[state=open]:border-accent-dimmer"
         : "bg-default border-outline-dimmest focus:border-accent-dimmest data-[state=open]:border-accent-dimmer",
-      small ? "h-8 py-1" : "h-10",
+      small ? "h-8 rounded-md" : "h-10 py-2 rounded-lg",
       className
     )}
     {...props}

--- a/lib/comparison.ts
+++ b/lib/comparison.ts
@@ -4,16 +4,19 @@ import { MetaPropertyType } from "@prisma/client"
 export type ComparableField =
   | {
       name: string
+      nonNullCount: number
       type: typeof MetaPropertyType.String
       values: [string, string | null][]
     }
   | {
       name: string
+      nonNullCount: number
       type: typeof MetaPropertyType.Number
       values: [string, number | null][]
     }
   | {
       name: string
+      nonNullCount: number
       type: typeof MetaPropertyType.Boolean
       values: [string, boolean | null][]
     }
@@ -69,12 +72,7 @@ export function toMutualMetadata(
               : MetaPropertyType.String
       }
     })
-    .sort((a, b) => b.nonNullCount - a.nonNullCount)
-    .map(({ name, values, type }) => ({
-      name,
-      values,
-      type
-    })) as Array<ComparableField>
+    .sort((a, b) => b.nonNullCount - a.nonNullCount) as Array<ComparableField>
 
   return sortedFields
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "bun db:sync && next build",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "tsc --noEmit && next lint",
     "db:seed": "bun prisma/seed/index.ts",
     "db:sync": "prisma migrate deploy && prisma generate",
     "format": "prettier --ignore-path .gitignore --write \"**/*.{js,ts,tsx}\" --plugin=prettier-plugin-organize-imports"


### PR DESCRIPTION
Fixes https://github.com/IroncladDev/ai-to-ai/issues/1
Fixes https://github.com/IroncladDev/ai-to-ai/issues/2
Fixes https://github.com/IroncladDev/ai-to-ai/issues/3
Fixes https://github.com/IroncladDev/ai-to-ai/issues/4

Added a new Filter popover.
<img width="610" alt="Screenshot 2024-02-18 at 8 06 55 AM" src="https://github.com/IroncladDev/ai-to-ai/assets/50180265/0e03ffc3-7577-451e-bd0c-bc3cca51cc08">

On moblie, the View option isn't needed since it always converts to a list.
Moved Null Fields and Standalone fields into the filter popover.
<img width="448" alt="Screenshot 2024-02-18 at 8 07 18 AM" src="https://github.com/IroncladDev/ai-to-ai/assets/50180265/a92a6fc3-4799-491e-a44e-233498cac03f">

Added basic markdown to the source description when you preview an LLM in review.

Added typescript to lint check.