### PR TITLE
fix: grid item height & alignment

### DIFF
--- a/app/compare/comparison.tsx
+++ b/app/compare/comparison.tsx
@@ -75,7 +75,7 @@ const ContainerOverflow = styled("div", {
 })
 
 const ItemsContainer = styled("div", {
-  base: "flex flex-col absolute inset-0 overflow-y-auto overflow-x-hidden gap-4 p-8 max-sm:p-2 max-sm:gap-2",
+  base: "flex flex-col absolute top-0 left-0 right-0 max-h-[100%] overflow-y-auto overflow-x-hidden gap-4 p-8 max-sm:p-2 max-sm:gap-2",
   variants: {
     view: {
       grid: "grid grid-cols-[repeat(auto-fit,_minmax(360px,_1fr))] justify-center justify-items-center",


### PR DESCRIPTION
cards were being unnecessarily stretchy (tall)

does not look good

![Screenshot 2024-02-21 at 1 09 21 PM](https://github.com/IroncladDev/ai-to-ai/assets/50180265/121a6fe7-7c51-439f-b963-0a1b57244ade)
